### PR TITLE
Added healthcheck to know if the Bot is working

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Tell you about meetings",
   "homepage": "https://github.com/product-os/open-office-bot#readme",
-  "main": "build/bot.js",
-  "types": "build/bot.d.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "keywords": [
     "balena",
     "typescript"
@@ -31,9 +31,9 @@
     "test": "npm run build && npm run lint && npm run test:node && npm run test:browser",
     "test:fast": "npm run build && npm run test:node",
     "prepack": "npm run build",
-    "start": "npm run build && node build/bot.js",
-    "dev": "env-cmd -f ./.env.dev ts-node-dev --respawn --transpile-only src/bot.ts",
-    "prod": "npm run build && PRODUCTION=1 env-cmd node build/bot.js"
+    "start": "npm run build && node build/index.js",
+    "dev": "env-cmd -f ./.env.dev ts-node-dev --respawn --transpile-only src/index.ts",
+    "prod": "npm run build && PRODUCTION=1 env-cmd node build/index.js"
   },
   "devDependencies": {
     "@balena/lint": "^5.4.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,12 @@
 export default {
+	healthcheck: {
+		port: process.env.HEALTHCHECK_PORT || 8000,
+	},
 	bot: {
 		statusInterval: 60 * 1000,
 	},
 	zulip: {
+		presenceInterval: 140000,
 		config: {
 			username: process.env.ZULIP_USERNAME || '',
 			apiKey: process.env.ZULIP_API_KEY || '',

--- a/src/healthcheck.ts
+++ b/src/healthcheck.ts
@@ -1,0 +1,46 @@
+import http from 'http';
+
+import config from './config';
+import Bot from './bot';
+import * as log from './logger';
+
+let server: http.Server | null = null;
+
+export function watch(bot: Bot) {
+	server = startHTTP((_req, res) => {
+		const botHealth = bot.hasErrors();
+		if (botHealth instanceof Error) {
+			res.statusCode = 503;
+			res.end(botHealth.message);
+			log.error(botHealth.message);
+		} else {
+			res.statusCode = 200;
+			res.end('OK');
+		}
+	});
+}
+
+export function stop() {
+	if (server) {
+		server.close();
+	}
+}
+
+function startHTTP(
+	cb: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+) {
+	const httpServer = http.createServer((req, res) => {
+		if (req.method === 'GET' && req.url === '/healthcheck') {
+			cb(req, res);
+		} else {
+			res.statusCode = 404;
+			res.end('Not found');
+		}
+	});
+
+	httpServer.listen(config.healthcheck.port, () => {
+		log.info(`Server running at http://localhost:${config.healthcheck.port}`);
+	});
+
+	return httpServer;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,16 @@
+import Bot from './bot';
+import * as healthcheck from './healthcheck';
+
+const bot = new Bot();
+
+// Watch bot so we can respond to /healthcheck HTTP requests
+healthcheck.watch(bot);
+
+// This listener won't exit the bot gracefully if process.exit() is called explicitly
+// elsewhere in the code, or if there's an uncaught exception, but otherwise it'll allow
+// an async function to run before exiting (which must be called manually).
+process.on('beforeExit', async () => {
+	await bot.stop();
+	healthcheck.stop();
+	process.exit(0);
+});

--- a/src/zulip.ts
+++ b/src/zulip.ts
@@ -12,6 +12,7 @@ type Config = {
 	realm: string;
 	streamName: string;
 };
+
 type Presence = 'active' | 'idle' | 'offline';
 
 type Profile = {
@@ -21,10 +22,11 @@ type Profile = {
 };
 
 export class Zulip extends EventEmitter {
+	public profile: Profile;
+	public presenceUpdatedAt: number = -Infinity;
 	private client: any | null;
 	private config: Config;
 	private heartbeat: NodeJS.Timer | null;
-	public profile: Profile;
 
 	constructor(config: Config, profile: Profile) {
 		super();
@@ -131,7 +133,9 @@ export class Zulip extends EventEmitter {
 			new_user_input: 'false',
 			slim_presence: 'true',
 		};
-		return this.request('/users/me/presence', 'POST', params);
+		const response = await this.request('/users/me/presence', 'POST', params);
+		this.presenceUpdatedAt = new Date().getTime();
+		return response;
 	}
 
 	private async persistPresence(status: Presence) {


### PR DESCRIPTION
This creates a `healthcheck` module which accepts a Bot to monitor. The healthcheck service exposes an HTTP server to respond to `GET /healthcheck` requests.

Healthchecks ask the provided Bot instance if it is healthy using a new hasErrors function. This function is used to convey if the bot is detecting errors based on if zulip or google meets is not being contacted within an interval.

When implementing this I saw the bot was not contacting google meet for the first minute because of the interval delay. I changed that so healthchecks could begin passing right away.