### PR TITLE
Increase wait timeout for meets page to 5 seconds

### DIFF
--- a/src/google-meet.ts
+++ b/src/google-meet.ts
@@ -52,7 +52,7 @@ export default async function (config: Config) {
 			// Google Meets is still querying the meet status for some moments after the
 			// status div has loaded.
 			await page.waitForSelector('div[role=status]');
-			await page.waitForTimeout(3000);
+			await page.waitForTimeout(5000);
 			return parseCountFromStatus(await getText(page, 'in this call'));
 		} catch (e: unknown) {
 			if (


### PR DESCRIPTION
It was previously 3 seconds which was changed in the last commit, but this wasn't enough sometimes apparently, so let's see if 5 seconds is any more consistent.

Change-type: patch